### PR TITLE
Move to a object based client

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,21 @@ Options:
   -h, --help                               display help for command
 
 Commands:
-  discover                                 Discover Twinkly devices on the network
-  getmovie [options]                       Get the current movie
-  getmovies [options]                      Get movies installed.
-  setmovie [options] <id>                  Set LED color in RGB
-  setcolor [options] <red> <green> <blue>  Set LED color in RGB
-  setopmode [options] <mode>               Set the LED operation mode
-  config <action> [value]                  Manage configuration settings
-  help [command]                           display help for command
+  discover [options]                             Discover Twinkly devices on the network.
+  getmovie [options]                             Get the current movie
+  getmovies [options]                            Get movies installed.
+  setmovie [options] <id>                        Set LED color in RGB
+  setcolor [options] <red> <green> <blue>        Set LED color in RGB
+  setopmode [options] <mode>                     Set the LED operation mode
+  config <action> [value]                        Manage configuration settings
+  setbrightness [options] <mode> <type> <value>  Send http request for changing brightness.
+  getbrightness [options]                        Get the brightness of the device.
+  getopmode [options]                            Get the current LED operation mode of the device.
+  getcolor [options]                             Get the color of the device.
+  getdetails [options]                           Get the details of the device.
+  gettimer [options]                             Get the timer set for the device.
+  settimer [options] <TimeOn> <TimeOff>          Send http request for setting timer.
+  help [command]                                 display help for command
 ```
 
 ## API Usage
@@ -51,13 +58,13 @@ twinklyjs is also available as a library. Most operations are available on the `
 ```js
 import {api} from '@twinklyjs/twinkly';
 
-api.init('10.0.0.187');
-const details = await api.getDeviceDetails();
+const client = new api.TwinklyClient({ip: '10.0.0.187'});
+const details = await client.getDeviceDetails();
 console.log(details);
 
-await api.setLEDOperationMode({mode: 'color'});
-await api.setLEDColor({r: 0, g: 255, b: 0});
-const data = await api.getLEDOperationMode();
+await client.setLEDOperationMode({mode: 'color'});
+await client.setLEDColor({r: 0, g: 255, b: 0});
+const data = await client.getLEDOperationMode();
 console.log(data);
 ```
 
@@ -95,10 +102,7 @@ There are a few examples of API usage available in `/examples`.
 This module currently only implements a subset of the available API.  We love contributions!  Feel free to open a PR, and reference the underlying part of the API you're trying to support.  See [CONTRIBUTING](CONTRIBUTING.md) to learn more.
 
 Want to join in on the discussion?
-visit our discord: https://discord.gg/AtA98tr2ab
-
-Want to join in on the discussion?
-visit our discord: https://discord.gg/AtA98tr2ab
+visit our discord: <https://discord.gg/AtA98tr2ab>
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@twinklyjs/twinkly",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@twinklyjs/twinkly",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,8 +82,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const movie = await api.getCurrentMovie();
+		const client = new api.TwinklyClient({ ip });
+		const movie = await client.getCurrentMovie();
 		console.log(movie);
 	});
 
@@ -93,8 +93,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const movies = await api.getMovies();
+		const client = new api.TwinklyClient({ ip });
+		const movies = await client.getMovies();
 		console.log(movies);
 	});
 
@@ -105,9 +105,9 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (id, options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		await api.setLEDOperationMode({ mode: api.LEDOperationMode.MOVIE });
-		const result = await api.setCurrentMovie({ id: Number(id) });
+		const client = new api.TwinklyClient({ ip });
+		await client.setLEDOperationMode({ mode: api.LEDOperationMode.MOVIE });
+		const result = await client.setCurrentMovie({ id: Number(id) });
 		console.log(result);
 	});
 
@@ -120,11 +120,9 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (red, green, blue, options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-
-		await api.setLEDOperationMode({ mode: api.LEDOperationMode.COLOR });
-
-		const result = await api.setLEDColor({
+		const client = new api.TwinklyClient({ ip });
+		await client.setLEDOperationMode({ mode: api.LEDOperationMode.COLOR });
+		const result = await client.setLEDColor({
 			red: Number(red),
 			green: Number(green),
 			blue: Number(blue),
@@ -145,9 +143,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (mode, options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-
-		const result = await api.setLEDOperationMode({
+		const client = new api.TwinklyClient({ ip });
+		const result = await client.setLEDOperationMode({
 			mode: mode as api.LEDOperationMode,
 		});
 		console.log(result);
@@ -200,8 +197,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (mode, type, value, options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const response = await api.setLEDBrightness({
+		const client = new api.TwinklyClient({ ip });
+		const response = await client.setLEDBrightness({
 			mode: mode as 'enabled' | 'disabled',
 			type: type as 'A' | 'R',
 			value: Number(value),
@@ -214,8 +211,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const details = await api.getLEDBrightness();
+		const client = new api.TwinklyClient({ ip });
+		const details = await client.getLEDBrightness();
 		console.log(details);
 	});
 
@@ -225,8 +222,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const details = await api.getLEDOperationMode();
+		const client = new api.TwinklyClient({ ip });
+		const details = await client.getLEDOperationMode();
 		console.log(details);
 	});
 
@@ -236,8 +233,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const details = await api.getLEDColor();
+		const client = new api.TwinklyClient({ ip });
+		const details = await client.getLEDColor();
 		console.log(details);
 	});
 
@@ -247,8 +244,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const details = await api.getDeviceDetails();
+		const client = new api.TwinklyClient({ ip });
+		const details = await client.getDeviceDetails();
 		console.log(details);
 	});
 
@@ -258,8 +255,8 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
-		const timer = await api.getTimer();
+		const client = new api.TwinklyClient({ ip });
+		const timer = await client.getTimer();
 
 		console.log(
 			`Time on: ${Math.floor(timer.time_on / 3600)}:${Math.floor((timer.time_on % 3600) / 60)} Time off: ${Math.floor(timer.time_off / 3600)}:${Math.floor((timer.time_off % 3600) / 60)} `,
@@ -279,7 +276,7 @@ program
 	.option('--ip <ip>', 'The IP address of the Twinkly device')
 	.action(async (TimeOn, TimeOff, options) => {
 		const ip = await requireIP(options.ip);
-		api.init(ip);
+		const client = new api.TwinklyClient({ ip });
 		const Now = new Date();
 		const hours = Now.getHours();
 		const minutes = Now.getMinutes();
@@ -287,7 +284,7 @@ program
 
 		const [timeOnHr, timeOnMin] = TimeOn.split(':');
 		const [timeOffHr, timeOffMin] = TimeOff.split(':');
-		const response = await api.setTimer({
+		const response = await client.setTimer({
 			time_now: hours * (60 * 60) + minutes * 60 + seconds,
 			time_on: timeOnHr * (60 * 60) + timeOnMin * 60,
 			time_off: timeOffHr * (60 * 60) + timeOffMin * 60,

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -4,12 +4,12 @@ import os from 'node:os';
 
 const UDP_BROADCAST_PORT = 5555;
 
-interface DiscoverOptions {
+export interface DiscoverOptions {
 	timeout?: number;
 	broadcastAddress?: string;
 }
 
-interface Device {
+export interface Device {
 	ip: string;
 	port: number;
 	deviceId: string;

--- a/test/test.api.ts
+++ b/test/test.api.ts
@@ -1,10 +1,11 @@
 import * as assert from 'node:assert';
 import { describe, it } from 'node:test';
-import { init, paths } from '../src/api.js';
+import { TwinklyClient } from '../src/api.js';
 
 describe('api', () => {
 	it('should allow setting the ip', async () => {
-		init('ippy');
-		assert.strictEqual(paths.ECHO, 'http://ippy/xled/v1/echo');
+		const ip = 'ippy';
+		const client = new TwinklyClient({ ip });
+		assert.ok(client);
 	});
 });


### PR DESCRIPTION
The current API assumes you're going to use a single IP.  When building out the Discord bot, I noticed keeping this all straight was misery.  This way you instantiate a client object, pass the IP, and then use that client moving forward.  