### PR TITLE
fix: realtime fragments off by 12 bytes

### DIFF
--- a/src/realtime.ts
+++ b/src/realtime.ts
@@ -38,7 +38,7 @@ export async function sendFrame(ip: string, token: string, nodes: LightNode[]) {
 			Buffer.from(token, 'base64'),
 			Buffer.from([0x00, 0x00, frame]),
 		];
-		for (let i = 12; i < 900 && light < nodes.length; i += 3) {
+		for (let i = 0; i < 900 && light < nodes.length; i += 3) {
 			const node = nodes[light];
 			messageParts.push(Buffer.from([node.r, node.g, node.b]));
 			light++;


### PR DESCRIPTION
Hey there! This patch is a small fix to the realtime feature.

I discovered the issue while working with a panel of 960 Twinkly LEDs. Certain LEDs wouldn't respond to the real-time instructions, and they were positioned in strange locations. After a bit of back-and-forth with my good buddy Claude, it was able to determine the issue:

The v3 realtime fragmentation loop in `sendFrame` uses `i < 900` as its bound while starting `i` at 12 (the header length), which caps each fragment's body at 888 bytes (296 LEDs) instead of the 900 bytes (300 LEDs) allowed by the protocol.

Since the device places fragment N at LED offset N * 300, every fragment after the first lands at the wrong position: a 4-LED gap appears at index 296, an 8-LED gap at 592, and a 12-LED gap at 888, with the data after each gap shifted accordingly.

The bug only manifests on devices with more than 300 LEDs (e.g. Twinkly Squares panels), which is likely why it hasn't been caught. Fix is to start `i` at 0 since it's counting body bytes, not absolute packet position.

Applying this fix corrects the problem and makes all of the LEDs respond as expected. Lacking automated test coverage, I'm not sure if there's a great way to test that it doesn't cause a regression, but it seems like a sensible change.