### PR TITLE
docs: add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ This module currently only implements a subset of the available API.  We love co
 Want to join in on the discussion?
 visit our discord: <https://discord.gg/AtA98tr2ab>
 
+## Security
+
+To report a vulnerability, please follow the instructions in [SECURITY](SECURITY.md).
+
 ## License
 
 [MIT](LICENSE.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest published release on the `main` branch.
+
+| Version | Supported |
+| -- | -- |
+| Latest release | :white_check_mark: |
+| Older releases | :x: |
+
+If you believe a vulnerability affects an older release, please still report it. Fixes may be shipped only in the latest version.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for suspected security vulnerabilities.
+
+Instead, report the issue privately to `justin.beckwith@gmail.com` with:
+
+- A description of the issue and its potential impact
+- Steps to reproduce or a proof of concept
+- The affected package version and runtime environment
+- Any relevant logs, request samples, or device details needed to reproduce
+
+You should avoid including secrets in your report, such as device auth tokens, Wi-Fi credentials, or private network information unless they are strictly necessary to explain the issue.
+
+You can expect an initial response within 5 business days. After triage, the maintainer will work with you on validation, remediation, and disclosure timing.
+
+## Disclosure
+
+Please allow time for a fix to be prepared before public disclosure. Once a fix is available, the remediation can be released through the normal GitHub and npm release process.


### PR DESCRIPTION
## Summary
- add a SECURITY.md with reporting instructions and supported-version guidance
- link the security policy from the README so it is easy to find

## Testing
- not run (docs-only change)