### PR TITLE
ci: skip npm publish when version already exists

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,19 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
           scope: '@twinklyjs'
+      - id: package-version
+        run: echo "version=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_OUTPUT"
+      - id: npm-check
+        run: |
+          if npm view "@twinklyjs/twinkly@${{ steps.package-version.outputs.version }}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.package-version.outputs.version }} is already published to npm; skipping publish."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: npm ci
+        if: ${{ steps.npm-check.outputs.published != 'true' }}
       - run: npm publish --access public --provenance
+        if: ${{ steps.npm-check.outputs.published != 'true' }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- detect whether the package version from package.json already exists on npm
- skip npm ci and npm publish when that version is already published
- leave the release-please job unchanged so GitHub tagging and changelog generation still work

## Root cause
The failed release run for chore(main): release twinkly 0.0.6 reached the publish job successfully, but npm rejected the publish because @twinklyjs/twinkly@0.0.6 was already published on January 15, 2025. Release Please was bootstrapped later from Git history and recreated the GitHub release/tag for 0.0.6, so the workflow attempted to publish an npm version that already existed.

## Result
Future runs are idempotent for already-published versions: the workflow will log that the version exists and skip publishing instead of failing the release workflow.

## Verification
- inspected failed run logs for workflow run 24977391371
- verified npm registry metadata for @twinklyjs/twinkly 0.0.6
- sanity-checked the updated workflow YAML