### PR TITLE
fix: clean up README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,14 @@ There are a few examples of API usage available in `/examples`.
 
 | Example | Description |
 |--|---|
-| [realtime](./examples/realtime.js) | Use the realtime UPD API to send light frames |
-|-|-|
+| [realtime](./examples/realtime.js) | Use the realtime UDP API to send light frames |
 
 ## Contributing
 
 This module currently only implements a subset of the available API.  We love contributions!  Feel free to open a PR, and reference the underlying part of the API you're trying to support.  See [CONTRIBUTING](CONTRIBUTING.md) to learn more.
 
 Want to join in on the discussion?
-visit our discord: <https://discord.gg/AtA98tr2ab>
+Visit our Discord: <https://discord.gg/AtA98tr2ab>
 
 ## Security
 


### PR DESCRIPTION
## Summary
- fix the README typo that said UPD instead of UDP
- remove the stray empty table row in the examples section
- normalize the Discord callout capitalization

## Why
This is a minimal fix PR that will also give release-please a new releasable fix commit on main. After this PR is merged, release-please should open the 0.0.7 release PR.

## Testing
- not run (README-only change)