### PR TITLE
chore(ci): fix npm provenance publish flow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,12 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      force-publish-current:
+        description: Publish the current package.json version from the selected ref even if no new GitHub release was created
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   release-please:
@@ -24,7 +30,7 @@ jobs:
   publish:
     needs:
       - release-please
-    if: ${{ needs.release-please.outputs.release_created == 'true' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' || (github.event_name == 'workflow_dispatch' && inputs['force-publish-current']) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,7 +42,19 @@ jobs:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
           scope: '@twinklyjs'
+      - id: package-version
+        run: echo "version=$(npm pkg get version | tr -d '\"')" >> "$GITHUB_OUTPUT"
+      - id: npm-check
+        run: |
+          if npm view "@twinklyjs/twinkly@${{ steps.package-version.outputs.version }}" version >/dev/null 2>&1; then
+            echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${{ steps.package-version.outputs.version }} is already published to npm; skipping publish."
+          else
+            echo "published=false" >> "$GITHUB_OUTPUT"
+          fi
       - run: npm ci
+        if: ${{ steps.npm-check.outputs.published != 'true' }}
       - run: npm publish --access public --provenance
+        if: ${{ steps.npm-check.outputs.published != 'true' }}
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "keywords": [],
   "author": "Justin Beckwith <justin.beckwith@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twinklyjs/twinklyjs"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.2.3",
     "@types/node": "^24.0.0",


### PR DESCRIPTION
## Summary
- add package repository metadata required by npm provenance verification
- skip publish cleanly when the target version already exists on npm
- add a manual workflow_dispatch recovery path to publish the current package version from main when no new GitHub release is being created

## Root cause
The 0.0.7 publish reached npm, but npm rejected the provenance bundle because package.json had no repository.url matching the GitHub repository. The exact error was:

> Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/twinklyjs/twinklyjs" from provenance

## Recovery after merge
1. Merge this PR.
2. Open the release workflow in GitHub Actions.
3. Run it manually with the workflow_dispatch input `force-publish-current=true` on `main`.
4. The workflow will publish the current 0.0.7 package from main without needing to create a fake 0.0.8 release.

## Notes
- This PR is intentionally `chore(ci):` so it should not trigger a new release by itself.
- It also includes the duplicate-version guard so already-published versions no longer fail the workflow.

## Verification
- inspected failed run 24977721861
- confirmed package.json metadata was missing
- verified updated package metadata locally with `npm pkg get repository`
- sanity-checked workflow YAML