### PR TITLE
fix: add repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
   "keywords": [],
   "author": "Justin Beckwith <justin.beckwith@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/twinklyjs/twinklyjs"
+  },
   "devDependencies": {
     "@biomejs/biome": "^2.2.3",
     "@types/node": "^24.0.0",


### PR DESCRIPTION
## Summary
- add the missing `repository` metadata to `package.json`

## Why
npm provenance verification for the 0.0.7 publish failed because `package.json` did not declare the repository URL expected by GitHub Actions provenance.

## Scope
This PR only changes `package.json`.